### PR TITLE
BaseAssertion add log

### DIFF
--- a/src/main/java/assertion/BaseAssertion.java
+++ b/src/main/java/assertion/BaseAssertion.java
@@ -4,9 +4,13 @@ import io.restassured.response.Response;
 import org.testng.asserts.SoftAssert;
 
 public class BaseAssertion {
+    private Response response;
 
     private BaseAssertion() {
+    }
 
+    public BaseAssertion(Response response) {
+        this.response = response;
     }
 
     public static void checkResponse(final Response response, final int statusCode) {
@@ -14,5 +18,34 @@ public class BaseAssertion {
         softAssert.assertEquals(response.statusCode(), statusCode, "Error - incorrect status code");
         softAssert.assertEquals(response.contentType(), "application/json");
         softAssert.assertAll();
+    }
+
+    public void checkResponse(LogResponse log, int statusCode){
+        switch(log.toString()) {
+            case "ALL":
+                response.then().log().all();
+                break;
+            case "STATUS":
+                response.then().log().status();
+                break;
+            case "HEADERS":
+                response.then().log().headers();
+                break;
+            case "BODY":
+                response.then().log().body();
+            case "IF_ERROR":
+                response.then().log().ifError();
+            default:
+                response.then().log().all();
+        }
+        SoftAssert softAssert = new SoftAssert();
+        softAssert.assertEquals(response.statusCode(), statusCode, "Error - incorrect status code");
+        softAssert.assertEquals(response.contentType(), "application/json");
+        softAssert.assertAll();
+    }
+
+    //version of previous method with default LogResponse : 'ALL'
+    public void checkResponse(int statusCode) {
+        checkResponse(LogResponse.ALL, statusCode);
     }
 }

--- a/src/main/java/assertion/LogResponse.java
+++ b/src/main/java/assertion/LogResponse.java
@@ -1,0 +1,5 @@
+package assertion;
+
+public enum LogResponse {
+    ALL, IF_ERROR, STATUS, HEADERS, BODY;
+}

--- a/src/main/java/client/UserClient.java
+++ b/src/main/java/client/UserClient.java
@@ -35,18 +35,18 @@ public class UserClient extends BaseClient {
     }
 
     public Response login(String name, String password) {
-        return given(baseRequestSpecification(ContentType.JSON))
+        return given(baseRequestSpecification())
                 .queryParam("name", name, "password", password)
                 .get(LOGIN_URL);
     }
 
     public Response logout() {
-        return given(baseRequestSpecification(ContentType.JSON))
+        return given(baseRequestSpecification())
                 .get(LOGOUT_URL);
     }
 
     public Response create(User user) {
-        return given(baseRequestSpecification(ContentType.JSON))
+        return given(baseRequestSpecification())
                 .body(user)
                 .post(USER_URL);
     }

--- a/src/test/java/api/user/UserClientPositiveTest.java
+++ b/src/test/java/api/user/UserClientPositiveTest.java
@@ -1,6 +1,7 @@
 package api.user;
 
 import assertion.BaseAssertion;
+import assertion.LogResponse;
 import assertion.UserAssertion;
 import builders.UserBuilder;
 import client.UserClient;
@@ -52,5 +53,11 @@ public class UserClientPositiveTest {
 
         Response response = userClient.updateByUsername("Malina", user);
         BaseAssertion.checkResponse(response, 200);
+    }
+
+    @Test
+    public void createTest() {
+        new BaseAssertion(userClient.create(userBuilder.constructRandomValidUser()))
+                .checkResponse(200);
     }
 }


### PR DESCRIPTION
Add new variant of usage to this class:

-in past you simply call 'static void checkResponse(Response r, int
statusCode)

-now you can at first create instance of class with response in constructor:

	new BaseAssertion(Response r)

and then call: 

        'void checkResponse(LogResponse log, int StatusCode)

or simply:
        
        'void checResponse(int StatusCode)' 

(default value of LogResponse in this case will be 'ALL')



P.S.

  LogResponse is simply new enum with all posible variants of lg modes